### PR TITLE
Accept strings in several forms of ascii hex notation.

### DIFF
--- a/mididings/util.py
+++ b/mididings/util.py
@@ -293,7 +293,11 @@ def subscene_number(subscene):
 def sysex_to_bytearray(sysex):
     if isinstance(sysex, str):
         if sysex.startswith('F0') or sysex.startswith('f0'):
-            return bytearray(int(x, 16) for x in sysex.split(sysex[2]))
+            if len(sysex) < 3 or sysex[2] not in ', \f\n\r\t\v':
+                return bytearray(int(sysex[i:i+2], 16)
+                                 for i in range(0, len(sysex), 2))
+            else:
+                return bytearray(int(x, 16) for x in sysex.split(sysex[2]))
         else:
             return bytearray(map(ord, sysex))
     elif isinstance(sysex, bytearray):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -114,9 +114,17 @@ class UtilTestCase(MididingsTestCase):
             sysex_data('f0,04,08,15,16,23,42,f7'),
             self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
         self.assertEqual(
+            sysex_data('F0040815162342F7'),
+            self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
+        self.assertEqual(
+            sysex_data('f0040815162342f7'),
+            self.native_sysex('\xf0\x04\x08\x15\x16\x23\x42\xf7'))
+        self.assertEqual(
             sysex_data('\xf0\x23\x42\x66', allow_partial=True),
             self.native_sysex('\xf0\x23\x42\x66'))
 
+        with self.assertRaises(ValueError):
+            sysex_data('F0')
         with self.assertRaises(ValueError):
             sysex_data('\xf0')
         with self.assertRaises(ValueError):


### PR DESCRIPTION
`sysex_to_bytearray`: accept strings in ascii hexadecimal notation with no whitespace between bytes

Hex without spaces, hex split by commas, and hex split by spaces are all valid input. Previously hex without spaces was not a valid way to format a sysex packet.